### PR TITLE
feat: reduce map size from 64x64 to 30x30

### DIFF
--- a/src/game/MapData.ts
+++ b/src/game/MapData.ts
@@ -26,12 +26,12 @@ function generateMap(width: number, height: number, seed = 42): number[][] {
         }
     }
 
-    // Place 10-15 water ponds
-    const pondCount = 10 + Math.floor(rng() * 6);
+    // Place 3-5 water ponds
+    const pondCount = 3 + Math.floor(rng() * 3);
     for (let p = 0; p < pondCount; p++) {
         const cx = 4 + Math.floor(rng() * (width - 8));
         const cy = 4 + Math.floor(rng() * (height - 8));
-        const radius = 2 + Math.floor(rng() * 4);
+        const radius = 1 + Math.floor(rng() * 3);
 
         for (let dy = -radius; dy <= radius; dy++) {
             for (let dx = -radius; dx <= radius; dx++) {


### PR DESCRIPTION
## Changes

- Reduced map dimensions from 64×64 to 30×30
- Scaled down pond generation (3–5 ponds, radius 1–3) to match smaller map area

## Testing

- Map renders correctly at 30×30
- Player and all NPCs spawn on grass and move normally
- Camera bounds adjust properly