### PR TITLE
feat: A* pathfinding for NPC movement

### DIFF
--- a/src/game/LLMService.ts
+++ b/src/game/LLMService.ts
@@ -3,7 +3,7 @@ Each turn you receive a map of the world showing terrain and entity positions.
 You are a helpful NPC — you explore the world.
 
 Available commands (you get up to 3 per turn):
-  move_to(x,y) — walk to tile (x,y)
+  move_to(x,y) — walk to tile (x,y), you don't have to specify the path, just the destination. 
   wait()       — do nothing this action
 
 Respond ONLY with commands, one per line. No commentary. Example:

--- a/src/game/Pathfinder.ts
+++ b/src/game/Pathfinder.ts
@@ -1,0 +1,76 @@
+import { TilePos } from './entities/Entity';
+
+/**
+ * A* pathfinding on a 4-directional grid.
+ * Returns the path from `start` (exclusive) to `goal` (inclusive),
+ * or null if no path exists.
+ */
+export function findPath(
+    start: TilePos,
+    goal: TilePos,
+    isWalkable: (x: number, y: number) => boolean,
+): TilePos[] | null {
+    if (start.x === goal.x && start.y === goal.y) return [];
+    if (!isWalkable(goal.x, goal.y)) return null;
+
+    const key = (x: number, y: number) => `${x},${y}`;
+    const DIRS: [number, number][] = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+
+    const gScore = new Map<string, number>();
+    const cameFrom = new Map<string, string>();
+    const startKey = key(start.x, start.y);
+    gScore.set(startKey, 0);
+
+    // Min-heap entries: [f, g, x, y]
+    const open: [number, number, number, number][] = [];
+    const h = (x: number, y: number) => Math.abs(x - goal.x) + Math.abs(y - goal.y);
+    open.push([h(start.x, start.y), 0, start.x, start.y]);
+
+    const closed = new Set<string>();
+
+    while (open.length > 0) {
+        // Find the entry with the lowest f score
+        let bestIdx = 0;
+        for (let i = 1; i < open.length; i++) {
+            if (open[i][0] < open[bestIdx][0]) bestIdx = i;
+        }
+        const [, g, cx, cy] = open[bestIdx];
+        open[bestIdx] = open[open.length - 1];
+        open.pop();
+
+        const ck = key(cx, cy);
+        if (closed.has(ck)) continue;
+        closed.add(ck);
+
+        if (cx === goal.x && cy === goal.y) {
+            // Reconstruct path
+            const path: TilePos[] = [];
+            let cur = ck;
+            while (cur !== startKey) {
+                const [px, py] = cur.split(',').map(Number);
+                path.push({ x: px, y: py });
+                cur = cameFrom.get(cur)!;
+            }
+            path.reverse();
+            return path;
+        }
+
+        for (const [dx, dy] of DIRS) {
+            const nx = cx + dx;
+            const ny = cy + dy;
+            const nk = key(nx, ny);
+            if (closed.has(nk)) continue;
+            if (!isWalkable(nx, ny) && !(nx === start.x && ny === start.y)) continue;
+
+            const ng = g + 1;
+            const prev = gScore.get(nk);
+            if (prev !== undefined && ng >= prev) continue;
+
+            gScore.set(nk, ng);
+            cameFrom.set(nk, ck);
+            open.push([ng + h(nx, ny), ng, nx, ny]);
+        }
+    }
+
+    return null;
+}

--- a/src/game/entities/EntityManager.ts
+++ b/src/game/entities/EntityManager.ts
@@ -29,4 +29,10 @@ export class EntityManager {
         if (this.isTileOccupied(x, y)) return false;
         return true;
     };
+
+    isTerrainWalkable = (x: number, y: number): boolean => {
+        if (x < 0 || x >= MAP_WIDTH || y < 0 || y >= MAP_HEIGHT) return false;
+        if (MAP_DATA[y][x] === TILE_WATER) return false;
+        return true;
+    };
 }

--- a/src/game/scenes/GameScene.ts
+++ b/src/game/scenes/GameScene.ts
@@ -135,7 +135,9 @@ export class GameScene extends Scene {
         for (const def of npcDefs) {
             const npc = new NPC(
                 this, this.map, def.tile,
-                this.entityManager.isWalkable, def.name, def.tint,
+                this.entityManager.isWalkable,
+                this.entityManager.isTerrainWalkable,
+                def.name, def.tint,
             );
             this.npcs.push(npc);
             this.entityManager.add(npc);


### PR DESCRIPTION
## Summary

Replace greedy axis-aligned NPC movement with A* pathfinding so NPCs navigate around concave water shapes instead of getting stuck.

## Problem

stepTowardAsync used greedy movement - prefer the axis with greater distance, fall back to the other axis. If both directions are blocked (e.g. concave water pond), the NPC gives up immediately.

## Solution

- Pathfinder.ts - A* with 4-directional movement and Manhattan distance heuristic
- EntityManager.isTerrainWalkable - walkability check ignoring entity positions for path planning
- NPC.walkToAsync - computes full A* path, walks step-by-step, re-paths up to 3 times if blocked
- Updated LLM prompt to clarify move_to only needs a destination
