### PR TITLE
feat: NPC chronological memory log system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 .env
 server/.env
 server/data/
+
+# NPC log files (generated at runtime)
+data/logs/chronological-*.md

--- a/doc/llm-integration.md
+++ b/doc/llm-integration.md
@@ -17,6 +17,8 @@ All NPCs share the same system prompt:
 ```
 You are an NPC in a 2D isometric tile-based game world.
 Each turn you receive a map of the world showing terrain and entity positions.
+You also receive YOUR MEMORY — a log of your past observations and actions.
+Use it to avoid revisiting the same areas and to make informed exploration decisions.
 You are a helpful NPC — you explore the world.
 
 Available commands (you get up to 3 per turn):
@@ -68,13 +70,27 @@ Each command runs to completion before the next one starts.
 
 The browser calls `POST /api/chat` on the Vite dev server. The `anthropic-proxy.mjs` plugin forwards it to the Anthropic Messages API.
 
-**Request body:**
+**Request body (without memory):**
 ```json
 {
   "system": "...",
-  "messages": [{ "role": "user", "content": "..." }]
+  "messages": [{ "role": "user", "content": "<world state>" }]
 }
 ```
+
+**Request body (with memory):**
+```json
+{
+  "system": "...",
+  "messages": [
+    { "role": "user", "content": "YOUR MEMORY:\n..." },
+    { "role": "assistant", "content": "Understood." },
+    { "role": "user", "content": "<world state>" }
+  ]
+}
+```
+
+Memory is sent as a prior conversation turn so the LLM treats it as background context, separate from the current world state snapshot.
 
 **Response:**
 ```json
@@ -83,14 +99,37 @@ The browser calls `POST /api/chat` on the Vite dev server. The `anthropic-proxy.
 }
 ```
 
+## Summarize Endpoint
+
+The `summarize-proxy.mjs` plugin provides `POST /api/summarize` for compressing old log entries.
+
+**Request:**
+```json
+{
+  "entries": "## Turn 1\n- I am at (15,10)\n..."
+}
+```
+
+**Response:**
+```json
+{
+  "summary": "I explored the northeast quadrant, starting from (15,10)..."
+}
+```
+
+Uses a dedicated system prompt that instructs the LLM to write a first-person summary preserving key locations and events.
+
 ## Configuration
 
 | Setting | Value | Location |
 |---------|-------|----------|
 | Model | claude-sonnet-4-20250514 | `vite/anthropic-proxy.mjs` |
-| Max tokens | 256 | `vite/anthropic-proxy.mjs` |
+| Max tokens (decisions) | 256 | `vite/anthropic-proxy.mjs` |
+| Max tokens (summaries) | 512 | `vite/summarize-proxy.mjs` |
 | Commands per turn | 3 | `src/game/TurnManager.ts` |
 | Delay between turns | 5 seconds | `src/game/TurnManager.ts` |
+| Summarize every N turns | 5 | `src/game/ChronologicalLog.ts` |
+| Log character budget | 4000 | `src/game/ChronologicalLog.ts` |
 | API key | `.env` file | `ANTHROPIC_API_KEY` |
 
 ## Error Handling
@@ -103,10 +142,15 @@ The browser calls `POST /api/chat` on the Vite dev server. The `anthropic-proxy.
 ## Debugging
 
 All prompts and responses are logged to the browser console:
-- **Blue** `[LLM] Ada's prompt` — system prompt + world state
+- **Blue** `[LLM] Ada's prompt` — system prompt, memory (if any), and world state
+- **Purple (light)** `Memory:` — chronological log content sent to the LLM
 - **Purple** `[LLM] Ada's response` — raw LLM output
 - **Green** `[Ada] move_to(12, 8)` — each directive as it executes
 
 ## Memory
 
-The LLM has **no memory** between turns. Each call is stateless — it receives only the current world state snapshot. There is no conversation history.
+NPCs have persistent memory via chronological log files stored at `data/logs/chronological-{Name}.md`. Each turn, the log records the NPC's position, visible entities, and executed actions. Old entries are periodically summarized into compressed paragraphs.
+
+At decision time, the log content is included in the prompt as a prior conversation turn (separate from the world state). The memory is capped at 4000 characters — the oldest summaries are dropped first if over budget, giving NPCs detailed recent memory and compressed older memory.
+
+See [architecture.md](architecture.md) for the full log format and summarization details.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,6 +1,6 @@
 # Agent World
 
-A Phaser 3 isometric game where NPCs are driven by an LLM (Anthropic Claude). The player moves freely on a 30x30 tile map while 3 NPCs take turns deciding what to do via Claude.
+A Phaser 3 isometric game where NPCs are driven by an LLM (Anthropic Claude). The player moves freely on a 30x30 tile map while 3 NPCs take turns deciding what to do via Claude. NPCs maintain a chronological log of their observations and actions, giving them memory of past turns.
 
 ## Tech Stack
 

--- a/doc/turn-system.md
+++ b/doc/turn-system.md
@@ -13,11 +13,15 @@ Turn 2: Ada → (5s) → Bjorn → (5s) → Cora → (5s) → "Turn 2 complete" 
 ```
 
 Each NPC turn:
-1. Build world state from the NPC's perspective
-2. Call the LLM for a decision
-3. Parse the response into directives
-4. Execute up to 3 commands, each running to completion
-5. Wait 5 seconds before the next NPC
+1. Record observations to the NPC's chronological log
+2. Build world state from the NPC's perspective
+3. Build memory content from the log (budget-capped)
+4. Call the LLM for a decision (world state + memory)
+5. Parse the response into directives
+6. Execute up to 3 commands, recording each action to the log
+7. Save the log to disk
+8. Summarize old log entries if enough have accumulated
+9. Wait 5 seconds before the next NPC
 
 ## Commands
 
@@ -47,6 +51,7 @@ A fixed label in the top-left corner shows:
 
 | File | Role |
 |------|------|
-| `src/game/TurnManager.ts` | Turn loop, directive execution, pause control |
+| `src/game/TurnManager.ts` | Turn loop, directive execution, log integration, pause control |
+| `src/game/ChronologicalLog.ts` | Per-NPC memory — recording, serialization, summarization |
 | `src/game/entities/NPC.ts` | `walkToAsync()`, `stepTowardAsync()` |
 | `src/game/entities/Entity.ts` | `moveToAsync()` — single-tile animated move |

--- a/src/game/ChronologicalLog.ts
+++ b/src/game/ChronologicalLog.ts
@@ -1,0 +1,197 @@
+// ── Configuration ───────────────────────────────────────────
+export const SUMMARIZE_EVERY_N_TURNS = 5;
+export const LOG_CHAR_BUDGET = 4000;
+
+// ── Data model ──────────────────────────────────────────────
+
+interface TurnEntry {
+    turnNumber: number;
+    lines: string[];
+}
+
+interface Summary {
+    turnStart: number;
+    turnEnd: number;
+    text: string;
+}
+
+// ── Serialization / parsing ─────────────────────────────────
+
+function serializeSummary(s: Summary): string {
+    return `## Summary (Turns ${s.turnStart}-${s.turnEnd})\n${s.text}`;
+}
+
+function serializeEntry(e: TurnEntry): string {
+    return `## Turn ${e.turnNumber}\n${e.lines.map(l => `- ${l}`).join('\n')}`;
+}
+
+function parseMarkdown(md: string): { summaries: Summary[]; entries: TurnEntry[] } {
+    const summaries: Summary[] = [];
+    const entries: TurnEntry[] = [];
+    if (!md.trim()) return { summaries, entries };
+
+    const sections = md.split(/^(?=## )/m);
+
+    for (const section of sections) {
+        const trimmed = section.trim();
+        if (!trimmed) continue;
+
+        const summaryMatch = trimmed.match(/^## Summary \(Turns (\d+)-(\d+)\)\n([\s\S]*)$/);
+        if (summaryMatch) {
+            summaries.push({
+                turnStart: parseInt(summaryMatch[1]),
+                turnEnd: parseInt(summaryMatch[2]),
+                text: summaryMatch[3].trim(),
+            });
+            continue;
+        }
+
+        const turnMatch = trimmed.match(/^## Turn (\d+)\n([\s\S]*)$/);
+        if (turnMatch) {
+            const lines = turnMatch[2]
+                .split('\n')
+                .map(l => l.replace(/^- /, '').trim())
+                .filter(l => l.length > 0);
+            entries.push({ turnNumber: parseInt(turnMatch[1]), lines });
+        }
+    }
+
+    return { summaries, entries };
+}
+
+// ── ChronologicalLog class ──────────────────────────────────
+
+export class ChronologicalLog {
+    private npcName: string;
+    private summaries: Summary[] = [];
+    private entries: TurnEntry[] = [];
+    private currentEntry: TurnEntry | null = null;
+
+    constructor(npcName: string) {
+        this.npcName = npcName;
+    }
+
+    async load(): Promise<void> {
+        const res = await fetch(`/api/logs/${encodeURIComponent(this.npcName)}`);
+        if (!res.ok) return;
+        const { content } = await res.json();
+        const parsed = parseMarkdown(content);
+        this.summaries = parsed.summaries;
+        this.entries = parsed.entries;
+    }
+
+    async save(): Promise<void> {
+        const parts: string[] = [];
+        for (const s of this.summaries) parts.push(serializeSummary(s));
+        for (const e of this.entries) parts.push(serializeEntry(e));
+        const content = parts.join('\n\n') + '\n';
+
+        await fetch(`/api/logs/${encodeURIComponent(this.npcName)}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content }),
+        });
+    }
+
+    startTurn(
+        turnNumber: number,
+        position: { x: number; y: number },
+        allEntities: { name: string; tilePos: { x: number; y: number } }[],
+    ): void {
+        const lines: string[] = [];
+        lines.push(`I am at (${position.x},${position.y})`);
+
+        const others = allEntities.filter(
+            e => !(e.tilePos.x === position.x && e.tilePos.y === position.y),
+        );
+        if (others.length > 0) {
+            const visible = others.map(e => `${e.name} at (${e.tilePos.x},${e.tilePos.y})`);
+            lines.push(`I can see: ${visible.join(', ')}`);
+        }
+
+        this.currentEntry = { turnNumber, lines };
+        this.entries.push(this.currentEntry);
+    }
+
+    recordAction(description: string): void {
+        if (this.currentEntry) {
+            this.currentEntry.lines.push(description);
+        }
+    }
+
+    buildPromptContent(charBudget: number): string {
+        if (this.summaries.length === 0 && this.entries.length === 0) return '';
+
+        const summaryTexts = this.summaries.map(s => serializeSummary(s));
+        const entryTexts = this.entries.map(e => serializeEntry(e));
+
+        // Start with all content
+        let combined = [...summaryTexts, ...entryTexts];
+        let result = combined.join('\n\n');
+
+        // Drop oldest summaries first if over budget
+        let dropIndex = 0;
+        while (result.length > charBudget && dropIndex < summaryTexts.length) {
+            dropIndex++;
+            combined = [...summaryTexts.slice(dropIndex), ...entryTexts];
+            result = combined.join('\n\n');
+        }
+
+        // If still over budget, drop oldest entries
+        let entryDropIndex = 0;
+        while (result.length > charBudget && entryDropIndex < entryTexts.length - 1) {
+            entryDropIndex++;
+            combined = [...summaryTexts.slice(dropIndex), ...entryTexts.slice(entryDropIndex)];
+            result = combined.join('\n\n');
+        }
+
+        return result;
+    }
+
+    async maybeSummarize(summarizeEveryN: number): Promise<void> {
+        if (this.entries.length <= summarizeEveryN) return;
+
+        // Entries eligible for summarization: everything except the last N
+        const toSummarize = this.entries.slice(0, this.entries.length - summarizeEveryN);
+        if (toSummarize.length < summarizeEveryN) return;
+
+        const entriesText = toSummarize.map(e => serializeEntry(e)).join('\n\n');
+
+        let summary: string;
+        try {
+            const res = await fetch('/api/summarize', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ entries: entriesText }),
+            });
+            if (!res.ok) {
+                console.warn(`[ChronologicalLog] Summarize failed for ${this.npcName}: HTTP ${res.status}`);
+                return;
+            }
+            const data = await res.json();
+            summary = data.summary;
+        } catch (err) {
+            console.warn(`[ChronologicalLog] Summarize error for ${this.npcName}:`, err);
+            return;
+        }
+
+        const turnStart = toSummarize[0].turnNumber;
+        const turnEnd = toSummarize[toSummarize.length - 1].turnNumber;
+
+        this.summaries.push({ turnStart, turnEnd, text: summary });
+        this.entries = this.entries.slice(toSummarize.length);
+
+        await this.save();
+    }
+
+    getLastTurnNumber(): number {
+        let last = 0;
+        for (const s of this.summaries) {
+            if (s.turnEnd > last) last = s.turnEnd;
+        }
+        for (const e of this.entries) {
+            if (e.turnNumber > last) last = e.turnNumber;
+        }
+        return last;
+    }
+}

--- a/src/game/LLMService.ts
+++ b/src/game/LLMService.ts
@@ -1,5 +1,7 @@
 const SYSTEM_PROMPT = `You are an NPC in a 2D isometric tile-based game world.
 Each turn you receive a map of the world showing terrain and entity positions.
+You also receive YOUR MEMORY — a log of your past observations and actions.
+Use it to avoid revisiting the same areas and to make informed exploration decisions.
 You are a helpful NPC — you explore the world.
 
 Available commands (you get up to 3 per turn):
@@ -18,18 +20,24 @@ export class LLMService {
         this.turnLabel = turnLabel ?? null;
     }
 
-    async decide(npcName: string, worldState: string): Promise<string> {
-        const userMessage = worldState;
-
+    async decide(npcName: string, worldState: string, memory?: string): Promise<string> {
         // ── Log prompt ──────────────────────────────────────
         console.group(`%c[LLM] ${npcName}'s prompt`, 'color: #6bc5ff; font-weight: bold');
         console.log('%cSystem:', 'color: #aaa', SYSTEM_PROMPT);
-        console.log('%cWorld state:', 'color: #aaa', userMessage);
+        if (memory) console.log('%cMemory:', 'color: #c9a0ff', memory);
+        console.log('%cWorld state:', 'color: #aaa', worldState);
         console.groupEnd();
+
+        const messages: { role: string; content: string }[] = [];
+        if (memory) {
+            messages.push({ role: 'user', content: `YOUR MEMORY:\n${memory}` });
+            messages.push({ role: 'assistant', content: 'Understood.' });
+        }
+        messages.push({ role: 'user', content: worldState });
 
         const body = {
             system: SYSTEM_PROMPT,
-            messages: [{ role: 'user', content: userMessage }],
+            messages,
         };
 
         let response: Response;

--- a/vite/config.dev.mjs
+++ b/vite/config.dev.mjs
@@ -1,9 +1,11 @@
 import { defineConfig } from 'vite';
 import { anthropicProxy } from './anthropic-proxy.mjs';
+import { logIO } from './log-io.mjs';
+import { summarizeProxy } from './summarize-proxy.mjs';
 
 export default defineConfig({
     base: './',
-    plugins: [anthropicProxy()],
+    plugins: [anthropicProxy(), logIO(), summarizeProxy()],
     build: {
         rollupOptions: {
             output: {

--- a/vite/log-io.mjs
+++ b/vite/log-io.mjs
@@ -1,0 +1,74 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { resolve } from 'path';
+
+const NPC_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Vite plugin that adds GET/POST /api/logs/:npcName endpoints for reading
+ * and writing per-NPC markdown log files under data/logs/.
+ */
+export function logIO() {
+    const logsDir = resolve(import.meta.dirname, '..', 'data', 'logs');
+
+    return {
+        name: 'log-io',
+        configureServer(server) {
+            // GET /api/logs/:npcName — read a log file
+            server.middlewares.use((req, res, next) => {
+                const match = req.url?.match(/^\/api\/logs\/([^/?]+)$/);
+                if (!match) return next();
+
+                const npcName = match[1];
+                if (!NPC_NAME_RE.test(npcName)) {
+                    res.statusCode = 400;
+                    res.end(JSON.stringify({ error: 'Invalid NPC name' }));
+                    return;
+                }
+
+                if (req.method === 'GET') {
+                    const filePath = resolve(logsDir, `chronological-${npcName}.md`);
+                    let content = '';
+                    try {
+                        content = readFileSync(filePath, 'utf-8');
+                    } catch { /* file doesn't exist yet */ }
+
+                    res.setHeader('Content-Type', 'application/json');
+                    res.end(JSON.stringify({ content }));
+                    return;
+                }
+
+                if (req.method === 'POST') {
+                    let body = '';
+                    req.on('data', chunk => { body += chunk; });
+                    req.on('end', () => {
+                        let parsed;
+                        try {
+                            parsed = JSON.parse(body);
+                        } catch {
+                            res.statusCode = 400;
+                            res.end(JSON.stringify({ error: 'Invalid JSON' }));
+                            return;
+                        }
+
+                        if (typeof parsed.content !== 'string') {
+                            res.statusCode = 400;
+                            res.end(JSON.stringify({ error: 'Missing content field' }));
+                            return;
+                        }
+
+                        mkdirSync(logsDir, { recursive: true });
+                        const filePath = resolve(logsDir, `chronological-${npcName}.md`);
+                        writeFileSync(filePath, parsed.content, 'utf-8');
+
+                        res.setHeader('Content-Type', 'application/json');
+                        res.end(JSON.stringify({ ok: true }));
+                    });
+                    return;
+                }
+
+                res.statusCode = 405;
+                res.end(JSON.stringify({ error: 'Method not allowed' }));
+            });
+        },
+    };
+}

--- a/vite/summarize-proxy.mjs
+++ b/vite/summarize-proxy.mjs
@@ -1,0 +1,95 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SUMMARIZE_MODEL = 'claude-sonnet-4-20250514';
+const SUMMARIZE_MAX_TOKENS = 512;
+const SUMMARIZE_SYSTEM_PROMPT =
+    'You are a memory compressor for an NPC in a 2D game. ' +
+    'Given a series of chronological log entries, produce a single concise narrative paragraph ' +
+    'that preserves key facts, decisions, spatial observations, and interactions. ' +
+    'Drop trivial or redundant details. Write in third person past tense.';
+
+// Load .env into process.env
+try {
+    const envPath = resolve(import.meta.dirname, '..', '.env');
+    const envFile = readFileSync(envPath, 'utf-8');
+    for (const line of envFile.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) continue;
+        const key = trimmed.slice(0, eq).trim();
+        const val = trimmed.slice(eq + 1).trim();
+        if (!process.env[key]) process.env[key] = val;
+    }
+} catch { /* .env file missing — rely on env vars */ }
+
+/**
+ * Vite plugin that adds a POST /api/summarize endpoint for compressing
+ * old chronological log entries via Anthropic Claude.
+ */
+export function summarizeProxy() {
+    return {
+        name: 'summarize-proxy',
+        configureServer(server) {
+            server.middlewares.use('/api/summarize', async (req, res) => {
+                if (req.method !== 'POST') {
+                    res.statusCode = 405;
+                    res.end(JSON.stringify({ error: 'Method not allowed' }));
+                    return;
+                }
+
+                const apiKey = process.env.ANTHROPIC_API_KEY;
+                if (!apiKey) {
+                    res.statusCode = 500;
+                    res.end(JSON.stringify({ error: 'ANTHROPIC_API_KEY not set' }));
+                    return;
+                }
+
+                let body = '';
+                for await (const chunk of req) {
+                    body += chunk;
+                }
+
+                let parsed;
+                try {
+                    parsed = JSON.parse(body);
+                } catch {
+                    res.statusCode = 400;
+                    res.end(JSON.stringify({ error: 'Invalid JSON' }));
+                    return;
+                }
+
+                const { entries } = parsed;
+                if (typeof entries !== 'string') {
+                    res.statusCode = 400;
+                    res.end(JSON.stringify({ error: 'Missing entries field' }));
+                    return;
+                }
+
+                try {
+                    const client = new Anthropic({ apiKey });
+                    const response = await client.messages.create({
+                        model: SUMMARIZE_MODEL,
+                        max_tokens: SUMMARIZE_MAX_TOKENS,
+                        system: SUMMARIZE_SYSTEM_PROMPT,
+                        messages: [{ role: 'user', content: entries }],
+                    });
+
+                    const summary = response.content
+                        .filter(b => b.type === 'text')
+                        .map(b => b.text)
+                        .join('');
+
+                    res.setHeader('Content-Type', 'application/json');
+                    res.end(JSON.stringify({ summary }));
+                } catch (err) {
+                    console.error('[summarize-proxy] API error:', err.message);
+                    res.statusCode = 502;
+                    res.end(JSON.stringify({ error: `Anthropic API error: ${err.message}` }));
+                }
+            });
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Replace greedy axis-aligned NPC movement with A* pathfinding so NPCs navigate around concave water shapes instead of getting stuck.

## Problem

stepTowardAsync used greedy movement - prefer the axis with greater distance, fall back to the other axis. If both directions are blocked (e.g. concave water pond), the NPC gives up immediately.

## Solution

- Pathfinder.ts - A* with 4-directional movement and Manhattan distance heuristic
- EntityManager.isTerrainWalkable - walkability check ignoring entity positions for path planning
- NPC.walkToAsync - computes full A* path, walks step-by-step, re-paths up to 3 times if blocked
- Updated LLM prompt to clarify move_to only needs a destination
