### PR TITLE
feat: Conversation system for NPC-NPC and Player-NPC dialogue

### DIFF
--- a/src/game/ChronologicalLog.ts
+++ b/src/game/ChronologicalLog.ts
@@ -184,6 +184,32 @@ export class ChronologicalLog {
         await this.save();
     }
 
+    recordConversation(transcript: {
+        partnerName: string;
+        turnNumber: number;
+        location: { x: number; y: number };
+        initiatedBy: string;
+        messages: { speaker: string; text: string }[];
+        endedBy: string;
+    }): void {
+        const lines: string[] = [];
+        lines.push(`### Conversation with ${transcript.partnerName} (Turn ${transcript.turnNumber})`);
+        lines.push(`Location: (${transcript.location.x}, ${transcript.location.y})`);
+        lines.push(`Initiated by: ${transcript.initiatedBy}`);
+        lines.push('');
+        for (const msg of transcript.messages) {
+            lines.push(`${msg.speaker}: ${msg.text}`);
+        }
+        lines.push(`[Conversation ended by ${transcript.endedBy}]`);
+
+        if (this.currentEntry) {
+            this.currentEntry.lines.push(lines.join('\n'));
+        } else {
+            // No current turn entry — create a standalone entry
+            this.entries.push({ turnNumber: transcript.turnNumber, lines });
+        }
+    }
+
     getLastTurnNumber(): number {
         let last = 0;
         for (const s of this.summaries) {

--- a/src/game/ConversationManager.ts
+++ b/src/game/ConversationManager.ts
@@ -1,0 +1,345 @@
+import { Entity, TilePos } from './entities/Entity';
+import { NPC } from './entities/NPC';
+import { Player } from './entities/Player';
+import { EntityManager } from './entities/EntityManager';
+import { LLMService, ConversationMessage, ConversationResponse } from './LLMService';
+import { ChronologicalLog, LOG_CHAR_BUDGET } from './ChronologicalLog';
+import { buildWorldState } from './WorldState';
+
+const MAX_EXCHANGES = 6;
+
+export interface ConversationSession {
+    initiator: Entity;
+    target: Entity;
+    history: ConversationMessage[];
+    turnNumber: number;
+    location: TilePos;
+}
+
+interface ConversationCallbacks {
+    showSpeechBubble: (entity: Entity, text: string, duration: number) => Promise<void>;
+    openDialogue: (targetName: string) => void;
+    closeDialogue: () => void;
+    addDialogueMessage: (speaker: string, text: string) => void;
+}
+
+export class ConversationManager {
+    private entityManager: EntityManager;
+    private llm: LLMService;
+    private logs: Map<string, ChronologicalLog>;
+    private callbacks: ConversationCallbacks;
+    private activeSession: ConversationSession | null = null;
+
+    // Player dialogue state
+    private playerInputResolve: ((text: string) => void) | null = null;
+    private playerDialogueClosed = false;
+
+    constructor(
+        entityManager: EntityManager,
+        llm: LLMService,
+        logs: Map<string, ChronologicalLog>,
+        callbacks: ConversationCallbacks,
+    ) {
+        this.entityManager = entityManager;
+        this.llm = llm;
+        this.logs = logs;
+        this.callbacks = callbacks;
+    }
+
+    isInConversation(): boolean {
+        return this.activeSession !== null;
+    }
+
+    getActiveSession(): ConversationSession | null {
+        return this.activeSession;
+    }
+
+    // ── NPC-to-NPC Conversation ─────────────────────────────
+
+    async startNpcConversation(
+        initiator: NPC,
+        targetName: string,
+        openingMessage: string,
+        turnNumber: number,
+    ): Promise<void> {
+        const validation = this.validate(initiator, targetName);
+        if (!validation.valid) {
+            console.warn(`%c[Conversation] ${validation.error}`, 'color: #ffaa00; font-weight: bold');
+            return;
+        }
+        const target = validation.target!;
+
+        // If the target is the Player, open dialogue box instead of running LLM loop
+        if (target instanceof Player) {
+            await this.startNpcToPlayerConversation(initiator, target, openingMessage, turnNumber);
+            return;
+        }
+
+        this.activeSession = {
+            initiator,
+            target,
+            history: [],
+            turnNumber,
+            location: { ...initiator.tilePos },
+        };
+
+        // Opening message from initiator
+        this.activeSession.history.push({ speaker: initiator.name, text: openingMessage });
+
+        // Show speech bubble and simultaneously call target's LLM
+        const entities = this.entityManager.getEntities();
+        const targetWorldState = buildWorldState(target, entities);
+        const targetMemory = this.logs.get(target.name)?.buildPromptContent(LOG_CHAR_BUDGET) || undefined;
+
+        const [, targetResponse] = await Promise.all([
+            this.callbacks.showSpeechBubble(initiator, openingMessage, 3000),
+            this.llm.converse(target.name, targetWorldState, targetMemory, this.activeSession.history),
+        ]);
+
+        let exchangeCount = 1; // opening message counts as 1
+
+        // Target responds
+        if (targetResponse.type === 'say') {
+            this.activeSession.history.push({ speaker: target.name, text: targetResponse.message });
+            await this.callbacks.showSpeechBubble(target, targetResponse.message, 3000);
+            exchangeCount++;
+        } else {
+            this.finishConversation(target.name);
+            return;
+        }
+
+        // Alternate back and forth
+        while (exchangeCount < MAX_EXCHANGES) {
+            // Initiator's turn
+            const initiatorWorldState = buildWorldState(initiator, entities);
+            const initiatorMemory = this.logs.get(initiator.name)?.buildPromptContent(LOG_CHAR_BUDGET) || undefined;
+            const initiatorResponse = await this.llm.converse(
+                initiator.name, initiatorWorldState, initiatorMemory, this.activeSession.history,
+            );
+
+            if (initiatorResponse.type === 'say') {
+                this.activeSession.history.push({ speaker: initiator.name, text: initiatorResponse.message });
+                await this.callbacks.showSpeechBubble(initiator, initiatorResponse.message, 3000);
+                exchangeCount++;
+            } else {
+                this.finishConversation(initiator.name);
+                return;
+            }
+
+            if (exchangeCount >= MAX_EXCHANGES) break;
+
+            // Target's turn
+            const targetResponse2 = await this.llm.converse(
+                target.name, targetWorldState, targetMemory, this.activeSession.history,
+            );
+
+            if (targetResponse2.type === 'say') {
+                this.activeSession.history.push({ speaker: target.name, text: targetResponse2.message });
+                await this.callbacks.showSpeechBubble(target, targetResponse2.message, 3000);
+                exchangeCount++;
+            } else {
+                this.finishConversation(target.name);
+                return;
+            }
+        }
+
+        // Hit exchange cap
+        this.finishConversation('exchange limit');
+    }
+
+    // ── NPC-to-Player Conversation ──────────────────────────
+
+    private async startNpcToPlayerConversation(
+        initiator: NPC,
+        player: Player,
+        openingMessage: string,
+        turnNumber: number,
+    ): Promise<void> {
+        this.activeSession = {
+            initiator,
+            target: player,
+            history: [],
+            turnNumber,
+            location: { ...initiator.tilePos },
+        };
+
+        // NPC's opening message
+        this.activeSession.history.push({ speaker: initiator.name, text: openingMessage });
+
+        // Show speech bubble for the opening, then open dialogue box
+        await this.callbacks.showSpeechBubble(initiator, openingMessage, 3000);
+
+        this.playerDialogueClosed = false;
+        this.callbacks.openDialogue(initiator.name);
+        this.callbacks.addDialogueMessage(initiator.name, openingMessage);
+
+        // Wait for player messages until dialogue is closed
+        while (!this.playerDialogueClosed) {
+            const playerText = await this.waitForPlayerInput();
+            if (this.playerDialogueClosed) break;
+
+            this.activeSession.history.push({ speaker: 'Player', text: playerText });
+            this.callbacks.addDialogueMessage('Player', playerText);
+
+            // NPC responds via LLM
+            const npcResponse = await this.sendPlayerMessageToNpc(initiator);
+            if (this.playerDialogueClosed) break;
+
+            if (npcResponse.type === 'say') {
+                this.activeSession.history.push({ speaker: initiator.name, text: npcResponse.message });
+                this.callbacks.addDialogueMessage(initiator.name, npcResponse.message);
+            } else {
+                this.activeSession.history.push({ speaker: initiator.name, text: '[ended conversation]' });
+                this.callbacks.addDialogueMessage(initiator.name, '(has nothing more to say)');
+            }
+        }
+
+        this.finishConversation('Player', true);
+    }
+
+    // ── Player-to-NPC Conversation ──────────────────────────
+
+    async startPlayerConversation(
+        player: Player,
+        target: NPC,
+        turnNumber: number,
+    ): Promise<void> {
+        if (this.activeSession) {
+            console.warn('%c[Conversation] Already in a conversation', 'color: #ffaa00; font-weight: bold');
+            return;
+        }
+        if (!player.isAdjacentTo(target)) {
+            console.warn('%c[Conversation] Target is not adjacent', 'color: #ffaa00; font-weight: bold');
+            return;
+        }
+
+        this.activeSession = {
+            initiator: player,
+            target,
+            history: [],
+            turnNumber,
+            location: { ...player.tilePos },
+        };
+
+        this.playerDialogueClosed = false;
+        this.callbacks.openDialogue(target.name);
+
+        // Wait for player messages until dialogue is closed
+        while (!this.playerDialogueClosed) {
+            const playerText = await this.waitForPlayerInput();
+            if (this.playerDialogueClosed) break;
+
+            this.activeSession.history.push({ speaker: 'Player', text: playerText });
+            this.callbacks.addDialogueMessage('Player', playerText);
+
+            const npcResponse = await this.sendPlayerMessageToNpc(target);
+            if (this.playerDialogueClosed) break;
+
+            if (npcResponse.type === 'say') {
+                this.activeSession.history.push({ speaker: target.name, text: npcResponse.message });
+                this.callbacks.addDialogueMessage(target.name, npcResponse.message);
+            } else {
+                this.activeSession.history.push({ speaker: target.name, text: '[ended conversation]' });
+                this.callbacks.addDialogueMessage(target.name, '(has nothing more to say)');
+            }
+        }
+
+        // Save transcript to NPC's log only
+        this.finishConversation('Player', true);
+    }
+
+    /** Called by the dialogue UI when the player submits a message. */
+    submitPlayerMessage(text: string): void {
+        if (this.playerInputResolve) {
+            this.playerInputResolve(text);
+            this.playerInputResolve = null;
+        }
+    }
+
+    /** Called when the player closes the dialogue box. */
+    closePlayerDialogue(): void {
+        this.playerDialogueClosed = true;
+        // Resolve any pending input wait
+        if (this.playerInputResolve) {
+            this.playerInputResolve('');
+            this.playerInputResolve = null;
+        }
+    }
+
+    // ── Private helpers ─────────────────────────────────────
+
+    private waitForPlayerInput(): Promise<string> {
+        return new Promise(resolve => {
+            this.playerInputResolve = resolve;
+        });
+    }
+
+    private async sendPlayerMessageToNpc(npc: NPC): Promise<ConversationResponse> {
+        const entities = this.entityManager.getEntities();
+        const worldState = buildWorldState(npc, entities);
+        const memory = this.logs.get(npc.name)?.buildPromptContent(LOG_CHAR_BUDGET) || undefined;
+        return this.llm.converse(npc.name, worldState, memory, this.activeSession!.history);
+    }
+
+    private finishConversation(endedBy: string, playerInvolved = false): void {
+        if (!this.activeSession) return;
+
+        const session = this.activeSession;
+        const transcript = {
+            partnerName: '',
+            turnNumber: session.turnNumber,
+            location: session.location,
+            initiatedBy: session.initiator.name,
+            messages: session.history,
+            endedBy,
+        };
+
+        if (playerInvolved) {
+            // Player involved: save to the NPC's log only (Player has no log)
+            const npcName = session.initiator instanceof Player
+                ? session.target.name
+                : session.initiator.name;
+            const npcLog = this.logs.get(npcName);
+            if (npcLog) {
+                npcLog.recordConversation({ ...transcript, partnerName: 'Player' });
+            }
+        } else {
+            // NPC-to-NPC: save to both logs
+            const initiatorLog = this.logs.get(session.initiator.name);
+            const targetLog = this.logs.get(session.target.name);
+            if (initiatorLog) {
+                initiatorLog.recordConversation({ ...transcript, partnerName: session.target.name });
+            }
+            if (targetLog) {
+                targetLog.recordConversation({ ...transcript, partnerName: session.initiator.name });
+            }
+        }
+
+        this.callbacks.closeDialogue();
+        this.activeSession = null;
+    }
+
+    private validate(
+        initiator: Entity,
+        targetName: string,
+    ): { valid: boolean; error?: string; target?: Entity } {
+        if (this.activeSession) {
+            return { valid: false, error: 'Already in a conversation' };
+        }
+
+        const target = this.entityManager.getByName(targetName);
+        if (!target) {
+            return { valid: false, error: `Target "${targetName}" does not exist` };
+        }
+
+        if (target === initiator) {
+            return { valid: false, error: 'Cannot start a conversation with yourself' };
+        }
+
+        if (!initiator.isAdjacentTo(target)) {
+            return { valid: false, error: `${targetName} is not adjacent to ${initiator.name}` };
+        }
+
+        return { valid: true, target };
+    }
+}

--- a/src/game/DirectiveParser.ts
+++ b/src/game/DirectiveParser.ts
@@ -8,10 +8,22 @@ export interface WaitDirective {
     type: 'wait';
 }
 
-export type Directive = MoveToDirective | WaitDirective;
+export interface StartConversationDirective {
+    type: 'start_conversation_with';
+    targetName: string;
+    message: string;
+}
+
+export interface EndConversationDirective {
+    type: 'end_conversation';
+}
+
+export type Directive = MoveToDirective | WaitDirective | StartConversationDirective | EndConversationDirective;
 
 const MOVE_TO_RE = /^move_to\(\s*(\d+)\s*,\s*(\d+)\s*\)$/;
 const WAIT_RE = /^wait\(\s*\)$/;
+const START_CONVO_RE = /^start_conversation_with\(\s*([A-Za-z_][A-Za-z0-9_ ]*)\s*,\s*(.+)\s*\)$/;
+const END_CONVO_RE = /^end_conversation\(\s*\)$/;
 
 export function parseDirectives(text: string): Directive[] {
     const directives: Directive[] = [];
@@ -26,6 +38,10 @@ export function parseDirectives(text: string): Directive[] {
             directives.push({ type: 'move_to', x: parseInt(match[1]), y: parseInt(match[2]) });
         } else if (WAIT_RE.test(line)) {
             directives.push({ type: 'wait' });
+        } else if ((match = line.match(START_CONVO_RE))) {
+            directives.push({ type: 'start_conversation_with', targetName: match[1].trim(), message: match[2].trim() });
+        } else if (END_CONVO_RE.test(line)) {
+            directives.push({ type: 'end_conversation' });
         } else {
             console.warn(`%c[DirectiveParser] Unknown directive: "${line}"`, 'color: #ffaa00; font-weight: bold');
         }

--- a/src/game/LLMService.ts
+++ b/src/game/LLMService.ts
@@ -5,13 +5,38 @@ Use it to avoid revisiting the same areas and to make informed exploration decis
 You are a helpful NPC — you explore the world.
 
 Available commands (you get up to 3 per turn):
-  move_to(x,y) — walk to tile (x,y), you don't have to specify the path, just the destination. 
+  move_to(x,y) — walk to tile (x,y), you don't have to specify the path, just the destination.
   wait()       — do nothing this action
+  start_conversation_with(Name, message) — you must be adjacent to entity to start a conversation
+  end_conversation() — end the current conversation
 
 Respond ONLY with commands, one per line. No commentary. Example:
 move_to(12,8)
-move_to(5,14)
+start_conversation_with(Bjorn, I noticed something at the eastern pond)
 wait()`;
+
+const CONVERSATION_SYSTEM_PROMPT = `You are an NPC in a conversation with another entity.
+Respond in character. Be concise.
+The purpose of conversation is to exchange useful information. 
+Do not make idle small talk. If you have nothing important to say, end the conversation.
+Keep your responses to 1-2 sentences.
+Do not communicate positions or map features.
+
+Respond with ONE of:
+  say(your message here)
+  end_conversation()`;
+
+export interface ConversationMessage {
+    speaker: string;
+    text: string;
+}
+
+export type ConversationResponse =
+    | { type: 'say'; message: string }
+    | { type: 'end_conversation' };
+
+const SAY_RE = /^say\((.+)\)$/;
+const END_CONVO_RESPONSE_RE = /^end_conversation\(\s*\)$/;
 
 export class LLMService {
     private turnLabel: Phaser.GameObjects.Text | null;
@@ -73,6 +98,80 @@ export class LLMService {
         return text;
     }
 
+    async converse(
+        npcName: string,
+        worldState: string,
+        memory: string | undefined,
+        conversationHistory: ConversationMessage[],
+    ): Promise<ConversationResponse> {
+        const messages: { role: string; content: string }[] = [];
+        if (memory) {
+            messages.push({ role: 'user', content: `YOUR MEMORY:\n${memory}` });
+            messages.push({ role: 'assistant', content: 'Understood.' });
+        }
+        messages.push({ role: 'user', content: `WORLD STATE:\n${worldState}` });
+        messages.push({ role: 'assistant', content: 'Understood.' });
+
+        const historyText = conversationHistory
+            .map(m => `${m.speaker}: ${m.text}`)
+            .join('\n');
+        messages.push({ role: 'user', content: `CONVERSATION:\n${historyText}\n\nRespond with say(message) or end_conversation().` });
+
+        const body = {
+            system: CONVERSATION_SYSTEM_PROMPT,
+            messages,
+        };
+
+        console.group(`%c[LLM] ${npcName}'s conversation response`, 'color: #ff9f43; font-weight: bold');
+        console.log('%cHistory:', 'color: #aaa', historyText);
+        console.groupEnd();
+
+        let response: Response;
+        try {
+            response = await fetch('/api/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+        } catch (err) {
+            this.reportError(npcName, `Network error: ${(err as Error).message}`);
+            return { type: 'end_conversation' };
+        }
+
+        if (!response.ok) {
+            let detail = `HTTP ${response.status}`;
+            try {
+                const errBody = await response.json();
+                detail = errBody.error ?? detail;
+            } catch { /* ignore parse error */ }
+            this.reportError(npcName, detail);
+            return { type: 'end_conversation' };
+        }
+
+        const data = await response.json();
+        const text: string = data.text.trim();
+
+        console.group(`%c[LLM] ${npcName}'s conversation response`, 'color: #ff9f43; font-weight: bold');
+        console.log(text);
+        console.groupEnd();
+
+        return this.parseConversationResponse(text);
+    }
+
+    private parseConversationResponse(text: string): ConversationResponse {
+        const line = text.split('\n')[0].trim();
+        const sayMatch = line.match(SAY_RE);
+        if (sayMatch) {
+            return { type: 'say', message: sayMatch[1].trim() };
+        }
+        if (END_CONVO_RESPONSE_RE.test(line)) {
+            return { type: 'end_conversation' };
+        }
+        // Fallback: treat unrecognized response as a say
+        console.warn(`%c[LLM] Unrecognized conversation response: "${line}", treating as say()`, 'color: #ffaa00');
+        return { type: 'say', message: text };
+    }
+
     private reportError(npcName: string, detail: string) {
         const msg = `[LLM ERROR] ${npcName}: ${detail}`;
         console.error(`%c${msg}`, 'color: #ff4444; font-weight: bold; font-size: 14px');
@@ -82,4 +181,4 @@ export class LLMService {
     }
 }
 
-export { SYSTEM_PROMPT };
+export { SYSTEM_PROMPT, CONVERSATION_SYSTEM_PROMPT };

--- a/src/game/WorldState.ts
+++ b/src/game/WorldState.ts
@@ -39,7 +39,7 @@ export function buildWorldState(observer: Entity, allEntities: Entity[]): string
     lines.push('. = grass (walkable), ~ = water (blocked), @ = you, P = player (blocked), A/B/C = NPCs (blocked)');
 
     lines.push('');
-    lines.push('ACTIONS: move_to(x,y) | wait()');
+    lines.push('ACTIONS: move_to(x,y) | wait() | start_conversation_with(Name, message) | end_conversation()');
 
     return lines.join('\n');
 }

--- a/src/game/entities/Entity.ts
+++ b/src/game/entities/Entity.ts
@@ -148,6 +148,12 @@ export abstract class Entity {
         });
     }
 
+    isAdjacentTo(other: Entity): boolean {
+        const dx = Math.abs(this.tilePos.x - other.tilePos.x);
+        const dy = Math.abs(this.tilePos.y - other.tilePos.y);
+        return (dx + dy) === 1;
+    }
+
     abstract update(time: number, delta: number): void;
 
     destroy() {

--- a/src/game/entities/EntityManager.ts
+++ b/src/game/entities/EntityManager.ts
@@ -23,6 +23,10 @@ export class EntityManager {
         return this.entities;
     }
 
+    getByName(name: string): Entity | undefined {
+        return this.entities.find(e => e.name === name);
+    }
+
     isWalkable = (x: number, y: number): boolean => {
         if (x < 0 || x >= MAP_WIDTH || y < 0 || y >= MAP_HEIGHT) return false;
         if (MAP_DATA[y][x] === TILE_WATER) return false;

--- a/src/game/entities/NPC.ts
+++ b/src/game/entities/NPC.ts
@@ -7,6 +7,9 @@ const MAX_REPATH_ATTEMPTS = 3;
 export class NPC extends Entity {
     private checkTerrainWalkable: (x: number, y: number) => boolean;
 
+    /** Set by TurnManager to enable mid-walk pause for player conversations. */
+    conversationPauseGate: (() => Promise<void>) | null = null;
+
     constructor(
         scene: Scene,
         map: Phaser.Tilemaps.Tilemap,
@@ -35,6 +38,9 @@ export class NPC extends Entity {
 
             for (const step of path) {
                 if (this.tilePos.x === target.x && this.tilePos.y === target.y) return;
+
+                // Check for conversation pause between steps
+                if (this.conversationPauseGate) await this.conversationPauseGate();
 
                 const dx = step.x - this.tilePos.x;
                 const dy = step.y - this.tilePos.y;

--- a/src/game/ui/DialogueBox.ts
+++ b/src/game/ui/DialogueBox.ts
@@ -1,0 +1,170 @@
+import { Scene } from 'phaser';
+
+const BOX_HEIGHT = 200;
+const BOX_MARGIN = 16;
+const INPUT_HEIGHT = 32;
+const MESSAGE_AREA_PAD = 12;
+
+export class DialogueBox {
+    private container: Phaser.GameObjects.Container;
+    private bg: Phaser.GameObjects.Graphics;
+    private titleText: Phaser.GameObjects.Text;
+    private messagesText: Phaser.GameObjects.Text;
+    private inputBg: Phaser.GameObjects.Graphics;
+    private inputDisplay: Phaser.GameObjects.Text;
+    private closeHint: Phaser.GameObjects.Text;
+    private htmlInput: HTMLInputElement;
+    private messages: string[] = [];
+    private onSubmitCallback: ((text: string) => void) | null = null;
+    private onCloseCallback: (() => void) | null = null;
+    private escKey: Phaser.Input.Keyboard.Key;
+    private visible = false;
+
+    constructor(scene: Scene) {
+        const cam = scene.cameras.main;
+        const boxW = cam.width - BOX_MARGIN * 2;
+        const boxX = BOX_MARGIN;
+        const boxY = cam.height - BOX_HEIGHT - BOX_MARGIN;
+
+        // Background panel
+        this.bg = scene.add.graphics();
+        this.bg.fillStyle(0x1a1a2e, 0.92);
+        this.bg.lineStyle(1, 0x6bc5ff, 0.6);
+        this.bg.fillRoundedRect(0, 0, boxW, BOX_HEIGHT, 8);
+        this.bg.strokeRoundedRect(0, 0, boxW, BOX_HEIGHT, 8);
+
+        // Title
+        this.titleText = scene.add.text(MESSAGE_AREA_PAD, 8, '', {
+            fontSize: '13px',
+            color: '#6bc5ff',
+            fontFamily: 'Arial, sans-serif',
+            fontStyle: 'bold',
+        });
+
+        // Messages area
+        const messagesAreaWidth = boxW - MESSAGE_AREA_PAD * 2;
+        this.messagesText = scene.add.text(MESSAGE_AREA_PAD, 28, '', {
+            fontSize: '12px',
+            color: '#e0e0e0',
+            fontFamily: 'Arial, sans-serif',
+            wordWrap: { width: messagesAreaWidth },
+            lineSpacing: 4,
+        });
+
+        // Input area background
+        this.inputBg = scene.add.graphics();
+        const inputY = BOX_HEIGHT - INPUT_HEIGHT - 8;
+        this.inputBg.fillStyle(0x0d0d1a, 0.8);
+        this.inputBg.fillRoundedRect(MESSAGE_AREA_PAD, inputY, messagesAreaWidth - 60, INPUT_HEIGHT, 4);
+
+        // Input display text (mirrors the hidden HTML input)
+        this.inputDisplay = scene.add.text(MESSAGE_AREA_PAD + 8, inputY + 8, 'Type a message...', {
+            fontSize: '12px',
+            color: '#888888',
+            fontFamily: 'Arial, sans-serif',
+        });
+
+        // Close hint
+        this.closeHint = scene.add.text(messagesAreaWidth - 40, inputY + 8, '[ESC] Close', {
+            fontSize: '10px',
+            color: '#888888',
+            fontFamily: 'Arial, sans-serif',
+        });
+
+        this.container = scene.add.container(boxX, boxY, [
+            this.bg,
+            this.titleText,
+            this.messagesText,
+            this.inputBg,
+            this.inputDisplay,
+            this.closeHint,
+        ]);
+        this.container.setScrollFactor(0);
+        this.container.setDepth(3000);
+        this.container.setVisible(false);
+
+        // Hidden HTML input for text capture
+        this.htmlInput = document.createElement('input');
+        this.htmlInput.type = 'text';
+        this.htmlInput.style.position = 'absolute';
+        this.htmlInput.style.opacity = '0';
+        this.htmlInput.style.pointerEvents = 'none';
+        this.htmlInput.style.left = '-9999px';
+        this.htmlInput.maxLength = 200;
+        document.body.appendChild(this.htmlInput);
+
+        this.htmlInput.addEventListener('input', () => {
+            const val = this.htmlInput.value;
+            this.inputDisplay.setText(val || 'Type a message...');
+            this.inputDisplay.setColor(val ? '#ffffff' : '#888888');
+        });
+
+        this.htmlInput.addEventListener('keydown', (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && this.htmlInput.value.trim()) {
+                e.preventDefault();
+                const text = this.htmlInput.value.trim();
+                this.htmlInput.value = '';
+                this.inputDisplay.setText('Type a message...');
+                this.inputDisplay.setColor('#888888');
+                if (this.onSubmitCallback) this.onSubmitCallback(text);
+            }
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                this.close();
+            }
+            // Stop propagation so game keys don't fire
+            e.stopPropagation();
+        });
+
+        // ESC key in Phaser as backup
+        this.escKey = scene.input.keyboard!.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+        this.escKey.on('down', () => {
+            if (this.visible) this.close();
+        });
+    }
+
+    open(targetName: string): void {
+        this.visible = true;
+        this.messages = [];
+        this.titleText.setText(`Conversation with ${targetName}`);
+        this.messagesText.setText('');
+        this.htmlInput.value = '';
+        this.inputDisplay.setText('Type a message...');
+        this.inputDisplay.setColor('#888888');
+        this.container.setVisible(true);
+        // Focus after a tick so the key event that opened the dialog doesn't fire
+        setTimeout(() => this.htmlInput.focus(), 50);
+    }
+
+    close(): void {
+        if (!this.visible) return;
+        this.visible = false;
+        this.container.setVisible(false);
+        this.htmlInput.blur();
+        if (this.onCloseCallback) this.onCloseCallback();
+    }
+
+    addMessage(speaker: string, text: string): void {
+        this.messages.push(`${speaker}: ${text}`);
+        // Keep only last ~8 messages visible
+        const visible = this.messages.slice(-8);
+        this.messagesText.setText(visible.join('\n'));
+    }
+
+    onSubmit(callback: (text: string) => void): void {
+        this.onSubmitCallback = callback;
+    }
+
+    onClose(callback: () => void): void {
+        this.onCloseCallback = callback;
+    }
+
+    isOpen(): boolean {
+        return this.visible;
+    }
+
+    destroy(): void {
+        this.container.destroy();
+        this.htmlInput.remove();
+    }
+}

--- a/src/game/ui/SpeechBubble.ts
+++ b/src/game/ui/SpeechBubble.ts
@@ -1,0 +1,83 @@
+import { Scene } from 'phaser';
+import { Entity } from '../entities/Entity';
+
+const BUBBLE_PAD_X = 10;
+const BUBBLE_PAD_Y = 6;
+const BUBBLE_MAX_WIDTH = 200;
+const ARROW_SIZE = 6;
+
+export class SpeechBubble {
+    private container: Phaser.GameObjects.Container;
+    private bg: Phaser.GameObjects.Graphics;
+    private text: Phaser.GameObjects.Text;
+    private entity: Entity;
+
+    constructor(scene: Scene, entity: Entity, message: string) {
+        this.entity = entity;
+
+        this.text = scene.add.text(0, 0, message, {
+            fontSize: '11px',
+            color: '#000000',
+            fontFamily: 'Arial, sans-serif',
+            wordWrap: { width: BUBBLE_MAX_WIDTH - BUBBLE_PAD_X * 2 },
+            lineSpacing: 2,
+        });
+        this.text.setOrigin(0.5, 1);
+
+        const textWidth = this.text.width;
+        const textHeight = this.text.height;
+        const boxW = textWidth + BUBBLE_PAD_X * 2;
+        const boxH = textHeight + BUBBLE_PAD_Y * 2;
+
+        this.bg = scene.add.graphics();
+        this.bg.fillStyle(0xffffff, 0.95);
+        this.bg.lineStyle(1, 0x333333, 0.8);
+        this.bg.fillRoundedRect(-boxW / 2, -boxH, boxW, boxH, 6);
+        this.bg.strokeRoundedRect(-boxW / 2, -boxH, boxW, boxH, 6);
+
+        // Arrow pointing down
+        this.bg.fillStyle(0xffffff, 0.95);
+        this.bg.fillTriangle(
+            -ARROW_SIZE, 0,
+            ARROW_SIZE, 0,
+            0, ARROW_SIZE,
+        );
+
+        this.text.setPosition(0, -BUBBLE_PAD_Y);
+
+        this.container = scene.add.container(0, 0, [this.bg, this.text]);
+        this.container.setDepth(2000);
+        this.updatePosition();
+    }
+
+    updatePosition(): void {
+        const spriteX = this.entity.sprite.x;
+        const spriteY = this.entity.sprite.y - this.entity.sprite.height * this.entity.sprite.originY - 20;
+        this.container.setPosition(spriteX, spriteY);
+    }
+
+    destroy(): void {
+        this.container.destroy();
+    }
+}
+
+export function showSpeechBubble(
+    scene: Scene,
+    entity: Entity,
+    message: string,
+    duration: number,
+): Promise<void> {
+    return new Promise(resolve => {
+        const bubble = new SpeechBubble(scene, entity, message);
+
+        // Update position each frame while bubble is alive
+        const updateHandler = () => bubble.updatePosition();
+        scene.events.on('update', updateHandler);
+
+        scene.time.delayedCall(duration, () => {
+            scene.events.off('update', updateHandler);
+            bubble.destroy();
+            resolve();
+        });
+    });
+}


### PR DESCRIPTION
## Summary

Adds a real-time conversation system that runs outside the turn-based NPC loop. Entities can exchange information through natural language dialogue via LLM calls, with speech bubbles (NPC-NPC) and an interactive dialogue box (Player-NPC).

## Changes

### New files
- **ConversationManager.ts** — Session management, validation, NPC-NPC exchange loop (6-exchange cap), NPC-to-Player and Player-to-NPC dialogue flows, transcript logging
- **ui/SpeechBubble.ts** — Styled bubble with arrow, positioned above NPC sprite, auto-follows entity
- **ui/DialogueBox.ts** — Phaser in-canvas panel with hidden HTML input for text capture

### Modified files
- **DirectiveParser.ts** — start_conversation_with and end_conversation directive types
- **LLMService.ts** — Conversation system prompt, converse() method
- **TurnManager.ts** — Conversation pause/resume, player-interrupt support
- **Entity.ts** — isAdjacentTo() (4-cardinal neighbor check)
- **EntityManager.ts** — getByName() lookup
- **NPC.ts** — Conversation pause checkpoint in walkToAsync()
- **GameScene.ts** — UI wiring, Enter key binding, input suppression during dialogue
- **ChronologicalLog.ts** — recordConversation() for transcript logging
- **WorldState.ts** — Updated ACTIONS line with new commands

## Key behaviors
- **NPC-NPC**: Speech bubbles (3s each), alternating LLM calls, 6-exchange cap, transcript saved to both logs
- **Player-NPC** (either direction): Dialogue box opens, human types freely, NPC responds via LLM, transcript saved to NPC log only
- Turn system pauses during any conversation and resumes after
- Player can interrupt NPC mid-turn by pressing Enter while adjacent
