### PR TITLE
fix: sync docs with codebase after reflection system merge

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -12,8 +12,8 @@ src/
     MapData.ts             Procedural 30x30 map (seeded PRNG, grass + water ponds)
     Pathfinder.ts          A* pathfinding on the tile grid
     WorldState.ts          Serializes game state into compact text for LLM consumption
-    LLMService.ts          Client-side LLM caller — sends decision & conversation prompts, logs I/O
-    DirectiveParser.ts     Parses LLM text responses into typed directive objects
+    LLMService.ts          Client-side LLM caller — sends decision & conversation prompts with optional reflection context, logs I/O
+    DirectiveParser.ts     Parses LLM text responses into typed directive objects and provides repair/validation helpers for output guard
     DirectiveExecutor.ts   Executes parsed directives — movement, tools, goals, sleep
     TurnManager.ts         Orchestrates NPC turn loop, sleep tracking, pause/resume
     FunctionBuilderService.ts Handles Code Forge validation, rejection feedback, and registration for LLM-generated code functions
@@ -24,6 +24,7 @@ src/
     ConversationManager.ts Manages NPC-NPC and player-NPC conversations via LLM
     GoalManager.ts         Per-NPC goal persistence — active/pending goals, promotion, serialization
     GoalExtractor.ts       Extracts new goals from conversation transcripts via LLM
+    ReflectionManager.ts   Per-NPC reflection persistence, staleness tracking, refresh triggers
     ToolBuilding.ts        Interface for interactive building objects (tools)
     ToolRegistry.ts        Registry mapping interactive building objects (tools) to their execution handlers
     ToolService.ts         Web search, structured code generation, sandboxed execution, and function persistence endpoints
@@ -31,6 +32,11 @@ src/
     FunctionBuilderService.test.ts Code Forge rejection-path coverage for create/update flows
     PersistedFunctionAudit.test.ts Startup cleanup coverage for unsupported saved functions
     validation.test.ts     Coverage for valid function specs and structured rejections
+    ChronologicalLog.test.ts Chronological log coverage
+    DirectiveParser.test.ts Directive parsing and repair/validation coverage
+    GoalExtractor.test.ts  Goal extraction coverage
+    LLMService.test.ts     LLM service coverage (decide/converse with reflection)
+    ReflectionManager.test.ts Reflection manager coverage
     entities/
       Entity.ts            Abstract base — sprite, tile movement, name label, sleep visuals
       Player.ts            Keyboard-controlled entity (arrows / WASD)
@@ -46,7 +52,7 @@ vite/
   config.dev.mjs           Dev config — includes all server plugins
   config.prod.mjs          Production build config (static only, no API plugins)
   anthropic-proxy.mjs      Vite plugin — proxies /api/chat to Anthropic API with fallback model chain
-  log-io.mjs               Vite plugin — reads/writes per-NPC log & goal .md files
+  log-io.mjs               Vite plugin — reads/writes per-NPC log, goal & reflection .md files
   search-proxy.mjs         Vite plugin — proxies /api/search to Tavily Search API
   code-executor.mjs        Vite plugin — sandboxed JS execution via /api/execute (VM, 1s timeout)
   functions-io.mjs         Vite plugin — CRUD for NPC-created function records via /api/functions

--- a/doc/conversations.md
+++ b/doc/conversations.md
@@ -28,7 +28,7 @@ NPC A emits start_conversation_with(B, opening)
   → Turn system resumes
 ```
 
-Both NPCs receive their own world state and memory alongside the conversation history when generating each reply.
+Both NPCs receive their own world state, memory, and reflection alongside the conversation history when generating each reply.
 
 ### Exchange Limit
 
@@ -60,7 +60,7 @@ Player presses Enter next to NPC
   → Turn system resumes
 ```
 
-The NPC receives its world state, memory, and the full conversation history each time it responds. It uses the `CONVERSATION` prompt config from `prompts.ts` — a dedicated prompt that instructs the NPC to be concise, exchange useful information, and end the conversation when it has nothing important to say.
+The NPC receives its world state, memory, reflection, and the full conversation history each time it responds. It uses the `CONVERSATION` prompt config from `prompts.ts` — a dedicated prompt that instructs the NPC to be concise, exchange useful information, and end the conversation when it has nothing important to say.
 
 ### Dialogue Box
 
@@ -93,7 +93,7 @@ These are available inside the conversation loop (via the `CONVERSATION` prompt 
 
 ## Conversation System Prompt
 
-During a conversation, NPCs use the `CONVERSATION` prompt config from `src/game/prompts.ts` (separate from the normal `DECISION` prompt). The prompt instructs the NPC to respond in character, be concise, exchange useful information, and end the conversation when it has nothing important to say.
+During a conversation, NPCs use the `CONVERSATION` prompt config from `src/game/prompts.ts` (separate from the normal `DECISION` prompt). The prompt instructs the NPC to respond in character, be concise, exchange useful information, and end the conversation when it has nothing important to say. Each NPC's reflection snapshot is also injected into the conversation context so learned strategies carry over into dialogue.
 
 ## Validation Rules
 
@@ -143,5 +143,6 @@ For NPC-to-NPC conversations, both NPCs get the transcript in their logs. For pl
 | `src/game/LLMService.ts` | `converse()` method for conversation LLM calls |
 | `src/game/prompts.ts` | `CONVERSATION` prompt config (model, tokens, system prompt) |
 | `src/game/GoalExtractor.ts` | Extracts goals from conversation transcripts via LLM |
+| `src/game/ReflectionManager.ts` | Per-NPC reflection persistence — refreshed after conversation goal changes |
 | `src/game/DirectiveParser.ts` | Parses `start_conversation_with` and `end_conversation` directives |
 | `src/game/TurnManager.ts` | Conversation pause/resume, player interrupt entry point |

--- a/doc/llm-integration.md
+++ b/doc/llm-integration.md
@@ -2,17 +2,17 @@
 
 ## Overview
 
-Each NPC's turn is driven by Anthropic Claude. The game sends the current world state, memory, and goals to the LLM and receives back a list of commands to execute. NPCs can also converse with each other and the player, with goals extracted from conversations automatically.
+Each NPC's turn is driven by Anthropic Claude. The game sends the current world state, memory, goals, and reflection to the LLM and receives back a list of commands to execute. NPCs can also converse with each other and the player, with goals extracted from conversations automatically.
 
 ## Flow
 
 ```
-NPC Turn → load log & goals → build world state → POST /api/chat → parse directives → execute commands → save log & goals
+NPC Turn → load log, goals & reflection → build world state → POST /api/chat → parse directives → execute commands → save log, goals & reflection
 ```
 
 ## Centralized Configuration
 
-LLM prompt configs live in `src/game/prompts.ts`. Each of the five LLM calls has its own `PromptConfig` object:
+LLM prompt configs live in `src/game/prompts.ts`. Each of the seven LLM calls has its own `PromptConfig` object:
 
 ```typescript
 interface PromptConfig {
@@ -22,19 +22,19 @@ interface PromptConfig {
 }
 ```
 
-The five configs are: `DECISION`, `CONVERSATION`, `SUMMARIZE`, `GOAL_EXTRACTION`, `CODE_GENERATION`.
+The seven configs are: `DECISION`, `CONVERSATION`, `SUMMARIZE`, `GOAL_EXTRACTION`, `CODE_GENERATION`, `REFLECTION`, `LESSON_LEARNED`.
 
 Model constants (`LLM_MODEL_OPUS`, `LLM_MODEL_SONNET`, `LLM_MODEL_HAIKU`) and gameplay tuning constants (`SUMMARIZE_EVERY_N_TURNS`, `LOG_CHAR_BUDGET`, `MAX_EXCHANGES`, `NPC_COMMANDS_PER_TURN`, `SLEEP_TURNS`) live in `src/game/GameConfig.ts`.
 
-## Five LLM Calls
+## Seven LLM Calls
 
 ### 1. Decision (`DECISION`)
 
 Used by `LLMService.decide()` each NPC turn. The system prompt defines the NPC's role, available commands, and goal/conversation directives.
 
-**Model:** Opus | **Max tokens:** 256
+**Model:** Opus | **Max tokens:** 320
 
-**Context sent:** memory (chronological log), active/pending goals, world state (map + entity positions + buildings).
+**Context sent:** memory (chronological log), active/pending goals, reflection, world state (map + entity positions + buildings).
 
 ### 2. Conversation (`CONVERSATION`)
 
@@ -42,13 +42,13 @@ Used by `LLMService.converse()` during multi-turn dialogue. The system prompt in
 
 **Model:** Opus | **Max tokens:** 512
 
-**Context sent:** memory, world state, full conversation history (as alternating user/assistant messages).
+**Context sent:** memory, reflection, world state, full conversation history (as alternating user/assistant messages).
 
 ### 3. Summarization (`SUMMARIZE`)
 
 Used by `ChronologicalLog.maybeSummarize()` to compress old log entries. The system prompt instructs the LLM to write a first-person summary preserving key locations, events, and conversations.
 
-**Model:** Haiku | **Max tokens:** 512
+**Model:** Haiku | **Max tokens:** 384
 
 **Context sent:** oldest unsummarized chronological log entries.
 
@@ -67,6 +67,22 @@ Used by `ToolService.generateFunctionSpec()` (working alongside `validation.ts`)
 **Model:** Sonnet | **Max tokens:** 512
 
 **Context sent:** natural-language description, optionally existing function code + change description.
+
+### 6. Reflection (`REFLECTION`)
+
+Used by `ReflectionManager.refreshIfStale()` to update the NPC's compact reflection state. The system prompt instructs the LLM to maintain a structured reflection record with obstacle/strategy lifecycle fields.
+
+**Model:** Sonnet | **Max tokens:** 256
+
+**Context sent:** trigger reasons, world state, chronological memory, current goals, recent failure/success events. The system prompt is parameterized with the NPC's name via `buildSystem(npcName)`.
+
+### 7. Lesson Learned (`LESSON_LEARNED`)
+
+Used by `ReflectionManager.generateCompletionLesson()` after a goal is completed. The system prompt instructs the LLM to write a short, reusable lesson learned from the successful goal completion.
+
+**Model:** Sonnet | **Max tokens:** 128
+
+**Context sent:** goal completion context, memory, world state. The system prompt is parameterized with the NPC's name via `buildSystem(npcName)`.
 
 Supported Code Forge work is limited to pure synchronous computation inside the sandbox. Unsupported capabilities include:
 
@@ -136,7 +152,7 @@ The browser calls API endpoints on the Vite dev server. In production builds, no
 
 ### LLM Proxy (`POST /api/chat`)
 
-The `anthropic-proxy.mjs` plugin forwards requests to the Anthropic Messages API. It handles all five LLM calls through this single endpoint. If a model returns 404, the proxy automatically retries with fallback models.
+The `anthropic-proxy.mjs` plugin forwards requests to the Anthropic Messages API. It handles all seven LLM calls through this single endpoint. If a model returns 404, the proxy automatically retries with fallback models.
 
 **Request body:**
 ```json
@@ -226,11 +242,11 @@ Before directives are executed, decision output goes through a hard guard:
 | Model (summarize) | Haiku | `src/game/prompts.ts` → `SUMMARIZE` |
 | Model (goal extraction) | Sonnet | `src/game/prompts.ts` → `GOAL_EXTRACTION` |
 | Model (code generation) | Sonnet | `src/game/prompts.ts` → `CODE_GENERATION` |
-| Max tokens (decision) | 256 | `src/game/prompts.ts` → `DECISION` |
+| Max tokens (decision) | 320 | `src/game/prompts.ts` → `DECISION` |
 | Max tokens (conversation) | 512 | `src/game/prompts.ts` → `CONVERSATION` |
 | Max tokens (reflection) | 256 | `src/game/prompts.ts` → `REFLECTION` |
 | Max tokens (lesson learned) | 128 | `src/game/prompts.ts` → `LESSON_LEARNED` |
-| Max tokens (summarize) | 512 | `src/game/prompts.ts` → `SUMMARIZE` |
+| Max tokens (summarize) | 384 | `src/game/prompts.ts` → `SUMMARIZE` |
 | Max tokens (goal extraction) | 256 | `src/game/prompts.ts` → `GOAL_EXTRACTION` |
 | Max tokens (code generation) | 512 | `src/game/prompts.ts` → `CODE_GENERATION` |
 | Commands per turn | 3 | `src/game/GameConfig.ts` → `NPC_COMMANDS_PER_TURN` |


### PR DESCRIPTION
## Summary

Fixes documentation discrepancies introduced after the reflection system merge (PR #17). The docs referenced stale LLM call counts, wrong token values, and were missing reflection context from several descriptions.

## Changes

### `doc/llm-integration.md`
- Fix LLM call count: "five" → **seven** (adds `REFLECTION` and `LESSON_LEARNED`)
- Add subsections for Reflection and Lesson Learned LLM calls
- Fix DECISION max tokens: 256 → **320**
- Fix SUMMARIZE max tokens: 512 → **384**
- Fix Configuration table with corrected token values
- Add reflection to flow diagram, overview paragraph, and context descriptions
- Fix proxy description to say "seven LLM calls"

### `doc/architecture.md`
- Add 6 missing files to file tree: `ReflectionManager.ts`, `ChronologicalLog.test.ts`, `DirectiveParser.test.ts`, `GoalExtractor.test.ts`, `LLMService.test.ts`, `ReflectionManager.test.ts`
- Update `LLMService.ts` description to mention reflection parameter
- Update `DirectiveParser.ts` description to mention repair/validation helpers
- Update `log-io.mjs` description to mention reflection file I/O

### `doc/conversations.md`
- Add reflection to NPC-to-NPC context description
- Add reflection to Player-to-NPC context description
- Update Conversation System Prompt section to mention reflection injection
- Add `ReflectionManager.ts` to Key Files table