### PR TITLE
docs: add evaluation system documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An isometric game where autonomous NPCs explore, make decisions, and hold conver
 - **Code Forge tools** — NPCs can create pure synchronous computation tools at runtime; requests requiring network access, filesystem access, databases, email sending, or other external side effects are rejected and written back into NPC memory
 - **Procedural map** — 30×30 isometric tile map with seeded terrain generation (grass + water ponds)
 - **Turn system** — Sequential NPC turns with pause/resume control
+- **Headless evaluation** — Run NPC scenarios from the command line without a browser, with success/fail/abort detection and JSON result output
 - **Feature toggles** — Toggle subsystems (conversations, goals, reflection, log summarization, function building, search terminal) at runtime via browser console with cascade dependencies
 
 ## Tech Stack
@@ -51,6 +52,20 @@ The dev server must be restarted after changing `.env`.
 | P | Pause / resume NPC turn loop |
 | Escape | Close dialogue box |
 
+## Evaluation
+
+Scenarios can be run headlessly from the command line — no browser needed. The evaluation system replicates the game's turn loop in pure Node.js:
+
+```bash
+# Run a single scenario
+npm run dev -- --test-scenario scenario-one
+
+# Run a suite of scenarios
+npm run dev -- --testing-mode scenario-one scenario-gather --title "nightly"
+```
+
+Results are written to `data/test-results/` as timestamped JSON files. See [Evaluation](doc/evaluation.md) for the full scenario authoring guide and architecture.
+
 ## How It Works
 
 Each game tick, NPCs take sequential turns. On its turn, an NPC receives a text-based snapshot of the world (a character grid with entity positions) plus its memory log and current goals. Claude responds with commands like `move_to(x,y)`, `wait()`, or `start_conversation_with(Name, message)`. Commands execute with animated movement and speech bubbles.
@@ -72,3 +87,4 @@ Detailed docs are in the [`doc/`](doc/) folder:
 | [Turn System](doc/turn-system.md) | NPC turn loop, commands, pause/resume |
 | [LLM Integration](doc/llm-integration.md) | Prompts, API proxy, memory, debugging |
 | [Conversations](doc/conversations.md) | NPC-NPC and Player-NPC conversation system |
+| [Evaluation](doc/evaluation.md) | Headless scenario runner, CLI usage, authoring guide |

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -48,6 +48,22 @@ src/
     ui/
       DialogueBox.ts       UI overlay for player-NPC conversation input
       SpeechBubble.ts      Floating speech bubble above speaking entities
+  eval/
+    dev-entry.ts           Unified npm run dev entry — routes to eval CLI or Vite server
+    cli.ts                 Argument parsing, Vite startup, single/suite orchestration
+    HeadlessTurnLoop.ts    Core headless turn loop — runScenario(), per-NPC turns, output guard
+    HeadlessConversationManager.ts  NPC-to-NPC conversation loop without Phaser
+    HeadlessDirectiveExecutor.ts    Executes directives in headless eval mode
+    HeadlessEntity.ts      HeadlessEntity + HeadlessNPC (instant A* pathfinding)
+    HeadlessEntityManager.ts  Entity storage + walkability from MAP_DATA
+    AbortMonitor.ts        Tracks repeated failures / invalid output for early abort
+    ResultWriter.ts        Prints terminal output + writes JSON result files
+    resetState.ts          Clears all persisted NPC state before a run
+    types.ts               TestScenario, ScenarioResult, SuiteResult, GameConfigSnapshot
+    scenarios/
+      index.ts             Scenario registry (getScenario, getAllScenarioIds)
+      scenario-one.ts      Navigation test — Ada walks to target tile
+      scenario-gather.ts   Cooperation test — Ada gathers Bjorn + Cora at meeting point
 vite/
   config.dev.mjs           Dev config — includes all server plugins
   config.prod.mjs          Production build config (static only, no API plugins)
@@ -64,6 +80,9 @@ data/
     reflection-{Name}.md
   functions/               NPC-created function records (JSON, generated at runtime)
     {function_name}.json
+  test-results/            Evaluation result JSON files (generated at runtime)
+    {scenario-id}.json
+    {scenario-id}-{timestamp}.json
 ```
 
 ## Scene Flow
@@ -112,6 +131,12 @@ Generated once at import time by `MapData.ts`. Uses a seeded PRNG (mulberry32, s
 The player is **not** part of the turn system and can move at any time.
 
 Press **P** to pause/resume the NPC turn loop.
+
+## Evaluation System
+
+The `src/eval/` tree provides a headless evaluation mode that replicates the browser turn loop in pure Node.js — no Phaser, no browser. Scenarios are run from the command line via `npm run dev -- --test-scenario <id>`. The headless loop uses the same `LLMService`, `ChronologicalLog`, `GoalManager`, and `ReflectionManager` as the browser game, but substitutes `HeadlessEntity`/`HeadlessNPC` (instant pathfinding), `HeadlessDirectiveExecutor`, and `HeadlessConversationManager` for their Phaser-dependent counterparts.
+
+See [evaluation.md](evaluation.md) for CLI usage, scenario authoring, result format, and the full headless architecture.
 
 ## Feature Toggles
 

--- a/doc/conversations.md
+++ b/doc/conversations.md
@@ -149,3 +149,15 @@ For NPC-to-NPC conversations, both NPCs get the transcript in their logs. For pl
 | `src/game/ReflectionManager.ts` | Per-NPC reflection persistence — refreshed after conversation goal changes |
 | `src/game/DirectiveParser.ts` | Parses `start_conversation_with` and `end_conversation` directives |
 | `src/game/TurnManager.ts` | Conversation pause/resume, player interrupt entry point |
+
+## Headless Conversations
+
+`HeadlessConversationManager` (in `src/eval/`) mirrors the NPC-to-NPC conversation flow for headless evaluation mode. It uses the same `LLMService.converse()` calls and `GoalExtractor` but has no Phaser, speech bubble, or UI dependencies.
+
+Key differences from the browser `ConversationManager`:
+- No speech bubbles or dialogue box — conversation messages are logged to the terminal
+- No Phaser scene or sprite dependencies
+- Sleep-waking is handled externally via an `onNpcEngaged` callback (wired by `HeadlessTurnLoop`)
+- Player conversations are not supported in headless mode
+
+See [evaluation.md](evaluation.md) for the full headless conversation flow and architecture.

--- a/doc/evaluation.md
+++ b/doc/evaluation.md
@@ -1,0 +1,254 @@
+# Evaluation System
+
+The evaluation system runs NPC scenarios headlessly — no Phaser, no browser. It replicates the game's turn loop in pure Node.js so scenarios can be executed, measured, and compared from the command line.
+
+## CLI Usage
+
+The `npm run dev` entry point routes to evaluation mode when it detects `--test-scenario` or `--testing-mode`:
+
+```bash
+# Run a single scenario
+npm run dev -- --test-scenario scenario-one
+
+# Run a single scenario with a label
+npm run dev -- --test-scenario scenario-gather --title "conversation test"
+
+# Run multiple scenarios as a suite
+npm run dev -- --testing-mode scenario-one scenario-gather
+
+# Suite with a label
+npm run dev -- --testing-mode scenario-one scenario-gather --title "nightly run"
+```
+
+Exit code is `0` on success, `1` on any failure or abort.
+
+## Available Scenarios
+
+| ID | Target NPC | Description | Max turns |
+|----|-----------|-------------|:---------:|
+| `scenario-one` | Ada | Navigate to a specific tile after a player instruction | 12 |
+| `scenario-gather` | Ada | Gather Bjorn and Cora at a meeting point via conversations | 25 |
+
+## Architecture
+
+```
+npm run dev -- --test-scenario <id>
+        │
+        ▼
+  dev-entry.ts          Detects --test-scenario / --testing-mode, delegates to cli.ts
+        │
+        ▼
+    cli.ts              Parses args, starts Vite on a random port, calls runScenario()
+        │
+        ▼
+  HeadlessTurnLoop      resetState() → seedChronologicalLog() → turn loop → result
+        │
+        ├─► HeadlessEntityManager      Entity positions + walkability (MAP_DATA)
+        ├─► HeadlessDirectiveExecutor   Executes directives (move, wait, converse, …)
+        ├─► HeadlessConversationManager NPC-to-NPC LLM conversations
+        ├─► AbortMonitor                Tracks repeated failures / invalid output
+        └─► ResultWriter                Prints + writes JSON results
+```
+
+### Entry point
+
+`dev-entry.ts` is the unified entry for `npm run dev`. When CLI args include `--test-scenario` or `--testing-mode`, it imports `cli.ts` directly (via tsx). Otherwise it spawns the Vite dev server for the browser game.
+
+### Vite server
+
+`cli.ts` starts a Vite dev server on a **random available port** (not 8080) so eval runs don't collide with a running browser game. The server provides the same API endpoints (LLM proxy, log I/O, etc.) that game modules call via `fetch()`. A `patchFetch()` shim rewrites relative URLs (`/api/chat`) to the random port's base URL.
+
+### Single vs. suite mode
+
+- **Single** (`--test-scenario <id>`): runs one scenario in-process, writes result, exits.
+- **Suite** (`--testing-mode <id> [...]`): spawns each scenario as a separate child process (isolated state), collects results, writes a suite summary.
+
+## Headless Entities
+
+| Class | Purpose |
+|-------|---------|
+| `HeadlessEntity` | Base — tracks `name`, `tilePos`, `sleeping` flag, adjacency checks |
+| `HeadlessNPC` | Adds `walkToAsync(target)` — A* pathfinding with re-path on blocked tiles, instant (no animation) |
+| `HeadlessEntityManager` | Stores entities, provides `isWalkable` / `isTerrainWalkable` from `MAP_DATA` arrays directly (no Phaser tilemap) |
+
+Movement is instant — `walkToAsync` walks the full A* path in a single call, re-pathing up to 5 times if tiles become occupied. No tweens, no frame delays.
+
+## Headless Conversations
+
+`HeadlessConversationManager` mirrors the browser `ConversationManager`'s NPC-to-NPC conversation loop without Phaser or UI dependencies.
+
+**Flow:**
+
+1. Initiator calls `start_conversation_with(Name, message)` → executor delegates to `startNpcConversation()`
+2. Validate: target exists, is adjacent, is not Player
+3. If target is sleeping, fire `onNpcEngaged` callback → wakes target (clears sleep, logs wake event)
+4. Opening message from initiator is added to history
+5. Alternating `llm.converse()` calls up to `MAX_EXCHANGES`, each participant seeing full history
+6. Conversation ends on `end_conversation()` response or exchange cap
+7. `finishConversation()` records transcript to both NPCs' chronological logs
+8. If goals enabled: `extractGoal()` runs for both participants
+9. If reflection enabled: goal results trigger reflection updates (obstacle/strategy lifecycle, completion lessons)
+
+**Key differences from browser `ConversationManager`:**
+- No speech bubbles or UI rendering
+- No Phaser scene or sprite dependencies
+- `onNpcEngaged` callback handles sleep-waking externally (via `HeadlessTurnLoop`'s `sleepUntil` map)
+
+## Headless Directive Executor
+
+`HeadlessDirectiveExecutor` handles the same directive set as the browser `DirectiveExecutor`:
+
+| Directive | Headless behavior |
+|-----------|-------------------|
+| `move_to(x,y)` | Instant A* pathfinding via `walkToAsync` |
+| `wait()` | No-op |
+| `start_conversation_with(Name, msg)` | Real LLM conversation via `HeadlessConversationManager` (when conversations enabled) |
+| `use_tool(id, args)` | Adjacency check + tool execution (tools return eval-mode placeholder) |
+| `sleep()` | Adds to `sleepUntil` map (rejected if NPC has active goal) |
+| `create_function` / `update_function` / `delete_function` | Skipped in eval mode |
+| Goal directives | Delegated to `GoalManager` (same as browser) |
+
+## Abort Monitoring
+
+`AbortMonitor` tracks the target NPC's behavior and triggers early abort when:
+
+| Rule | Threshold | Description |
+|------|:---------:|-------------|
+| Repeated invalid output | 2 | Output guard fell back to `wait()` twice in one run |
+| Repeated failed action loop | 3 | Same failed action (type + target + failure key) 3 times consecutively |
+| Runtime error | — | Unhandled exception during `runScenario()` (caught externally) |
+
+A successful action resets the consecutive failure counter.
+
+## Turn Loop
+
+`HeadlessTurnLoop.runScenario()` replicates the browser `TurnManager` loop:
+
+1. **Setup** — create entities at configured spawn points, load persisted logs/goals/reflections
+2. **Per global turn** — iterate all NPCs sequentially:
+   - Skip sleeping NPCs (wake if turn threshold reached)
+   - Build world state, memory, goals, reflection context
+   - Call `llm.decide()` → output guard → parse directives
+   - Execute goal directives (no budget cost), then action directives (capped at `NPC_COMMANDS_PER_TURN`)
+   - Persist logs, run summarization if enabled, persist goals + reflection
+3. **Post-turn evaluation** (priority order):
+   - `checkSuccess()` → **SUCCESS**
+   - `AbortMonitor.checkDefaultAborts()` → **ABORTED**
+   - `scenario.checkAbort()` → **ABORTED** (scenario-specific)
+   - Max turns reached → **FAIL**
+
+## Per-Scenario Feature Overrides
+
+`TestScenario` has an optional `features` field:
+
+```ts
+features?: Partial<Record<FeatureKey, boolean>>;
+```
+
+When set, `runScenario()` applies the overrides to the global `FEATURES` object before running, and restores the originals in a `finally` block. Scenarios that omit `features` run with whatever the global config has.
+
+## Result Format
+
+### Single scenario (`ScenarioResult`)
+
+```json
+{
+  "scenarioId": "scenario-gather",
+  "targetNpc": "Ada",
+  "result": "SUCCESS",
+  "globalTurnsElapsed": 3,
+  "npcTurnsTaken": 3,
+  "failureReason": null,
+  "maxGlobalTurns": 25,
+  "config": {
+    "models": { "opus": "...", "sonnet": "...", "haiku": "..." },
+    "tuning": { "summarizeEveryNTurns": 5, "..." : "..." },
+    "features": { "conversations": true, "goals": true, "..." : "..." }
+  },
+  "timestamp": "2026-03-16T10:30:00.000Z",
+  "title": "conversation test"
+}
+```
+
+### Suite (`SuiteResult`)
+
+```json
+{
+  "mode": "testing-mode",
+  "scenarios": [ { "scenarioId": "...", "result": "...", "..." : "..." } ],
+  "summary": { "successCount": 2, "failCount": 0, "abortedCount": 0 }
+}
+```
+
+Results are written to `data/test-results/`:
+- **Stable file**: `<scenario-id>.json` — overwritten each run (used by suite orchestrator)
+- **History file**: `<scenario-id>-<timestamp>.json` — never overwritten
+
+## State Management
+
+Before each scenario run:
+
+1. `resetState()` deletes all `.md` files in `data/logs/` and all `.json` files in `data/functions/` — blank slate
+2. `scenario.seedChronologicalLog()` writes the initial chronological log(s) that give the target NPC its starting context (e.g. a prior player instruction)
+
+This means eval runs are fully isolated and do not depend on prior game state.
+
+## Authoring a New Scenario
+
+1. Create `src/eval/scenarios/scenario-<name>.ts` implementing `TestScenario`:
+
+```ts
+import { TestScenario, EvalGameState } from '../types';
+
+const scenario: TestScenario = {
+    id: 'scenario-<name>',
+    targetNpc: 'Ada',       // NPC tracked by AbortMonitor
+    maxGlobalTurns: 15,
+
+    async seedChronologicalLog(): Promise<void> {
+        // Write initial log files to data/logs/
+    },
+
+    checkSuccess(state: EvalGameState): boolean {
+        // Return true when the scenario objective is met
+        return false;
+    },
+
+    // Optional: scenario-specific abort conditions
+    checkAbort(state: EvalGameState) {
+        return null; // or { reason: 'description' }
+    },
+};
+
+export default scenario;
+```
+
+2. Register in `src/eval/scenarios/index.ts`:
+
+```ts
+import scenarioName from './scenario-<name>';
+
+// Add to SCENARIOS map:
+[scenarioName.id, scenarioName],
+```
+
+3. Run: `npm run dev -- --test-scenario scenario-<name>`
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/eval/dev-entry.ts` | Unified `npm run dev` entry — routes to eval CLI or Vite server |
+| `src/eval/cli.ts` | Argument parsing, Vite startup, single / suite orchestration |
+| `src/eval/HeadlessTurnLoop.ts` | Core turn loop — `runScenario()`, per-NPC turns, output guard |
+| `src/eval/HeadlessConversationManager.ts` | NPC-to-NPC conversation loop without Phaser |
+| `src/eval/HeadlessDirectiveExecutor.ts` | Executes directives (move, converse, tool use, sleep) |
+| `src/eval/HeadlessEntity.ts` | `HeadlessEntity` + `HeadlessNPC` (instant pathfinding) |
+| `src/eval/HeadlessEntityManager.ts` | Entity storage + walkability from MAP_DATA |
+| `src/eval/AbortMonitor.ts` | Tracks repeated failures / invalid output for early abort |
+| `src/eval/ResultWriter.ts` | Prints terminal output + writes JSON result files |
+| `src/eval/resetState.ts` | Clears all persisted NPC state before a run |
+| `src/eval/types.ts` | `TestScenario`, `ScenarioResult`, `SuiteResult`, `GameConfigSnapshot` |
+| `src/eval/scenarios/index.ts` | Scenario registry (`getScenario`, `getAllScenarioIds`) |
+| `src/eval/scenarios/scenario-one.ts` | Navigation test — Ada walks to target tile |
+| `src/eval/scenarios/scenario-gather.ts` | Cooperation test — Ada gathers Bjorn + Cora at meeting point |

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -42,3 +42,7 @@ The dev server must be restarted after changing `.env`.
 ## Feature Toggles
 
 Subsystems can be toggled at runtime from the browser dev console via `FEATURES.<name> = false`. Six flags are available: `conversations`, `goals`, `reflection`, `logSummarization`, `functionBuilding`, `searchTerminal`. Cascade rules apply: disabling `conversations` also disables goals and reflection; disabling `goals` also disables reflection. See [architecture.md](architecture.md#feature-toggles) for details.
+
+## Evaluation
+
+Scenarios can be run headlessly from the command line — no browser needed. The evaluation system replicates the turn loop in pure Node.js with success/fail/abort detection and JSON result output. See [evaluation.md](evaluation.md) for CLI usage, scenario authoring, and architecture.

--- a/doc/turn-system.md
+++ b/doc/turn-system.md
@@ -145,3 +145,16 @@ A fixed label in the top-left corner shows:
 | `src/game/ConversationManager.ts` | Multi-turn NPC-NPC and player-NPC conversations |
 | `src/game/entities/NPC.ts` | `walkToAsync()` with optimistic pathfinding |
 | `src/game/entities/Entity.ts` | `moveToAsync()`, sleep visuals |
+
+## Headless Turn Loop
+
+`HeadlessTurnLoop` (in `src/eval/`) replicates the browser `TurnManager` loop for headless evaluation. It uses the same `LLMService`, `DirectiveParser`, `ChronologicalLog`, `GoalManager`, and `ReflectionManager`, but substitutes headless versions of the entity system and directive executor.
+
+Key differences from the browser turn loop:
+- No Phaser — entities are plain objects with instant A* pathfinding (no tweens or animation delays)
+- Vite dev server starts on a random available port (not 8080) with `patchFetch()` for relative API URLs
+- An `AbortMonitor` tracks the target NPC for repeated failures or invalid output and can trigger early abort
+- Post-turn evaluation checks `checkSuccess()` → `checkAbort()` → max turns, producing a `ScenarioResult`
+- No 5-second inter-turn delay
+
+See [evaluation.md](evaluation.md) for CLI usage, scenario authoring, and the full headless architecture.


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the evaluation system across all relevant doc files.

## Changes

- **`doc/evaluation.md`** — New file. Full evaluation system reference covering CLI usage, available scenarios, headless architecture (entities, conversations, directive executor, abort monitoring), turn loop flow, per-scenario feature overrides, result format, state management, scenario authoring guide, and key files table.
- **`README.md`** — Add "Headless evaluation" feature bullet, "Evaluation" section with CLI examples, doc table row linking to `doc/evaluation.md`.
- **`doc/overview.md`** — Add evaluation mention to features list.
- **`doc/architecture.md`** — Add `src/eval/` file subtree to File Structure, add `data/test-results/` to data listing, add "Evaluation System" paragraph with link.
- **`doc/conversations.md`** — Add "Headless Conversations" section describing `HeadlessConversationManager` and differences from browser flow.
- **`doc/turn-system.md`** — Add "Headless Turn Loop" section describing `HeadlessTurnLoop` and differences from browser `TurnManager`.

No code changes. `doc/llm-integration.md` unchanged (same 7 LLM calls used in both modes).

Depends on #25.