### PR TITLE
fix(test): enable logSummarization flag in ChronologicalLog test

### DIFF
--- a/src/game/ChronologicalLog.test.ts
+++ b/src/game/ChronologicalLog.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ChronologicalLog, parseStructuredSummaryText } from './ChronologicalLog';
+import { FEATURES } from './GameConfig';
 
 describe('parseStructuredSummaryText', () => {
     it('parses and normalizes a valid structured summary', () => {
@@ -30,9 +31,11 @@ describe('parseStructuredSummaryText', () => {
 describe('ChronologicalLog maybeSummarize', () => {
     afterEach(() => {
         vi.restoreAllMocks();
+        FEATURES.logSummarization = false;
     });
 
     it('falls back to raw text when structured parsing fails', async () => {
+        FEATURES.logSummarization = true;
         const capturedSaves: string[] = [];
         const fetchMock = vi.fn(async (input: string, init?: RequestInit) => {
             if (input.includes('/chat')) {


### PR DESCRIPTION
The `maybeSummarize` fallback test was failing because the `logSummarization` feature flag now defaults to `false` (changed in the eval system PRs). The test didn't enable the flag before calling `maybeSummarize()`.

**Fix:** Import `FEATURES` from `GameConfig` and explicitly enable `logSummarization` before the test, restoring it in `afterEach`.

**Verification:**
- All 30 unit tests pass
- `scenario-one` eval: SUCCESS (1 turn)